### PR TITLE
fix: last increment count after switching fragments

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -16,7 +16,7 @@
     </option>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/neilkrishna/basicapplication/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/neilkrishna/basicapplication/ui/home/HomeFragment.kt
@@ -5,7 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
 import com.neilkrishna.basicapplication.databinding.FragmentHomeBinding
 
@@ -17,31 +19,42 @@ class HomeFragment : Fragment() {
     // onDestroyView.
     private val binding get() = _binding!!
 
+    private val viewModel: HomeViewModel by viewModels()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
+        collectUIState()
         return binding.root
     }
 
 
-    var num=0;
+    // var num=0;
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         binding.increment.setOnClickListener { view1 ->
             //The counter is being incremented by 1 each time it is pressed and the result is displayed.
-            num+=1;
-            binding.counter.text=num.toString();
-            
+            // num+=1;
+            // binding.counter.text=num.toString();
+            viewModel.increaseCountByOne()
         }
 
         binding.addPeople.setOnClickListener { view2 ->
             Snackbar.make(view2, "Replace with your own action to add person", Snackbar.LENGTH_LONG)
                 .setAction("Action", null).show()
+        }
+    }
+
+    private fun collectUIState () = lifecycleScope.launchWhenStarted {
+        viewModel.uiState.collect { state ->
+            binding.apply {
+                counter.text = state.count.toString()
+            }
         }
     }
 

--- a/app/src/main/java/com/neilkrishna/basicapplication/ui/home/HomeScreenState.kt
+++ b/app/src/main/java/com/neilkrishna/basicapplication/ui/home/HomeScreenState.kt
@@ -1,0 +1,5 @@
+package com.neilkrishna.basicapplication.ui.home
+
+data class HomeScreenState(
+    val count: Int = 0
+)

--- a/app/src/main/java/com/neilkrishna/basicapplication/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/neilkrishna/basicapplication/ui/home/HomeViewModel.kt
@@ -1,0 +1,16 @@
+package com.neilkrishna.basicapplication.ui.home
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class HomeViewModel constructor(
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeScreenState())
+    val uiState = _uiState.asStateFlow()
+
+    fun increaseCountByOne() {
+        _uiState.value = uiState.value.copy(count = uiState.value.count + 1)
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

After incrementing count in Home Fragment and then switching fragment from Home to Profile or People, count in Home Fragment is getting initialized to 0 again, it is not equal to previous count.

I have used `View Model` to store that count and displaying it in Home Fragment, which fixed this bug 🐛.

📷

https://user-images.githubusercontent.com/40730402/194153676-f82740cc-ae0f-47f1-a16f-5035fc706aed.mp4



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
